### PR TITLE
Delete "automatiquement" to fix On/Off layout

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -49,7 +49,7 @@ Copyright (C) 2012  James Roberts
     <string name="current_min">Vitesse minimum :\u00A0</string>
     <string name="governor">Stratégie</string>
     <string name="io">Horloge E/S</string>
-    <string name="sob">Appliquer automatiquement au démarrage</string>
+    <string name="sob">Appliquer au démarrage</string>
     <string name="ok">OK</string>
     <string name="cancel">Annuler</string>
     <string name="cpu_info_list_header">Statut des cœurs</string>


### PR DESCRIPTION
There is a bug with the Layout of on/off button, we can't see the off.
And for me "automatiquement" is useless because "apply at start"  "Appliquer au démarrage" is just the user need to understand the function
![screenshot_2014-03-08-16-05-33](https://f.cloud.github.com/assets/6277284/2365636/412590f4-a6d3-11e3-80a1-d68d135bfa82.png)
